### PR TITLE
docs: add requirement docs for all open issues

### DIFF
--- a/docs/requirements/authentication.md
+++ b/docs/requirements/authentication.md
@@ -1,0 +1,72 @@
+# Issue #3 — Authentication Module
+
+## Objective
+
+Implement the full authentication flow using Supabase Auth, with protected routes and shared auth state.
+
+## Reference
+
+- `docs/requirements.md` — Section 2.1
+- `supabase/migrations/20260217000001_create_schema.sql` — `profiles` table + trigger
+
+---
+
+## Steps
+
+### 1. Auth service (`src/modules/auth/services/auth.service.ts`)
+
+All Supabase Auth calls go here — never in components or views.
+
+```ts
+signUp(email: string, password: string): Promise<...>
+signIn(email: string, password: string): Promise<...>
+signOut(): Promise<...>
+getSession(): Promise<...>
+onAuthStateChange(callback): Unsubscribable
+```
+
+### 2. Auth composable (`src/modules/auth/composables/useAuth.ts`)
+
+Reactive wrapper over the service. Exposes:
+
+```ts
+const { user, isAuthenticated, loading, error } = useAuth()
+```
+
+Restores session on page reload via `onAuthStateChange`.
+
+### 3. Views
+
+| View | Route | Purpose |
+| ---- | ----- | ------- |
+| `LoginView.vue` | `/login` | Email + password sign in |
+| `RegisterView.vue` | `/register` | Email + password sign up |
+
+### 4. Router guards
+
+Protect all non-auth routes. Redirect unauthenticated users to `/login`. Redirect authenticated users away from `/login` and `/register`.
+
+### 5. Types (`src/modules/auth/types/index.ts`)
+
+```ts
+interface AuthUser {
+  id: string
+  email: string
+}
+
+interface AuthError {
+  message: string
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] User can register with email + password
+- [ ] User can log in
+- [ ] User can log out
+- [ ] Session persists on page reload
+- [ ] Unauthenticated users are redirected to `/login`
+- [ ] No Supabase calls in components or views
+- [ ] All types defined — no `any`

--- a/docs/requirements/focus-mode.md
+++ b/docs/requirements/focus-mode.md
@@ -1,0 +1,54 @@
+# Issue #8 — Focus Mode
+
+## Objective
+
+Implement a distraction-free, full-screen view that isolates a single active task.
+
+## Reference
+
+- `docs/requirements.md` — Section 2.6
+- Issue #5 (Tasks module) — must be completed first
+
+---
+
+## Steps
+
+### 1. View (`src/modules/focus/views/FocusView.vue`)
+
+- Full-screen layout, no sidebar or navigation
+- Displays only the active task: title, description, energy level, impact score
+- Single action: mark task as done
+- Entry via route `/focus/:taskId`
+
+### 2. Layout
+
+```
+.focus
+.focus__task
+.focus__task-title
+.focus__task-description
+.focus__task-meta
+.focus__action
+.focus__exit
+```
+
+### 3. Transitions
+
+- Smooth entry transition when entering focus mode
+- Smooth exit transition back to previous view (Kanban or Projects)
+
+### 4. Behaviour
+
+- Marking task as done calls `tasks.service.updateStatus(id, 'done')` and navigates back
+- Exit button returns to previous route without changing task status
+
+---
+
+## Acceptance Criteria
+
+- [ ] Full-screen layout with no navigation chrome
+- [ ] Displays only the selected task
+- [ ] Task can be marked as done
+- [ ] Exit returns to previous view
+- [ ] Entry and exit transitions are smooth
+- [ ] BEM styles, no utility classes

--- a/docs/requirements/graph.md
+++ b/docs/requirements/graph.md
@@ -1,0 +1,69 @@
+# Issue #7 — Graph View
+
+## Objective
+
+Implement a canvas-based graph where tasks are nodes, connections are edges, and positions persist in Supabase. The graph module loads only when accessed (lazy loaded).
+
+## Reference
+
+- `docs/requirements.md` — Section 2.5
+- `supabase/migrations/20260217000001_create_schema.sql` — `task_connections` table
+- Issue #5 (Tasks module) — must be completed first
+
+---
+
+## Steps
+
+### 1. Rendering
+
+- Use the Canvas API or SVG (no external graph library)
+- Each task is a node: display title, status color
+- Connections are directed edges between nodes
+- Nodes are positioned using `task.position_x` / `task.position_y`
+
+### 2. Interactions
+
+- **Drag nodes** — update position on drag end, persist via `tasks.service.updatePosition`
+- **Create connection** — click source node → click target node → save via connections service
+- **Zoom and pan** — basic canvas transform (scale + translate)
+
+### 3. Graph service (`src/modules/graph/services/graph.service.ts`)
+
+```ts
+fetchConnections(projectId: string): Promise<TaskConnection[]>
+createConnection(sourceId: string, targetId: string): Promise<TaskConnection>
+deleteConnection(id: string): Promise<void>
+```
+
+### 4. Types (`src/modules/graph/types/index.ts`)
+
+```ts
+interface TaskConnection {
+  id: string
+  source_task_id: string
+  target_task_id: string
+}
+
+interface NodePosition {
+  id: string
+  x: number
+  y: number
+}
+```
+
+### 5. Performance
+
+- Module is **lazy loaded** — only imported when the `/graph` route is accessed
+- Avoid re-rendering the full canvas on every state change — diff only changed nodes
+
+---
+
+## Acceptance Criteria
+
+- [ ] Tasks render as nodes on a canvas
+- [ ] Connections render as edges between nodes
+- [ ] Nodes are draggable and positions persist
+- [ ] Connections can be created manually
+- [ ] Zoom and pan work
+- [ ] Module is lazy loaded
+- [ ] No external graph library

--- a/docs/requirements/kanban.md
+++ b/docs/requirements/kanban.md
@@ -1,0 +1,64 @@
+# Issue #6 — Kanban Board
+
+## Objective
+
+Implement a three-column Kanban board with drag-and-drop and a cognitive overload protection (WIP limit).
+
+## Reference
+
+- `docs/requirements.md` — Section 2.4
+- Issue #5 (Tasks module) — must be completed first
+
+---
+
+## Steps
+
+### 1. View (`src/modules/kanban/views/KanbanView.vue`)
+
+Three columns rendered from task status:
+
+| Column | Status |
+| ------ | ------ |
+| To Do  | `todo` |
+| Doing  | `doing` |
+| Done   | `done` |
+
+### 2. Drag and drop
+
+- Use the native HTML5 Drag and Drop API (no external library)
+- On drop: call `tasks.service.updateStatus(id, newStatus)`
+- Keep interactions under 16ms frame budget
+
+### 3. WIP limit — max 3 tasks in "Doing"
+
+- If dropping into "Doing" would exceed 3 tasks: block the drop and show a visual overload warning
+- Warning is inline — no modal, no toast
+
+### 4. Components
+
+| Component | Purpose |
+| --------- | ------- |
+| `KanbanColumn.vue` | Single column with header and task list |
+| `KanbanCard.vue` | Draggable task card — BEM block `.kanban-card` |
+
+### 5. BEM classes
+
+```
+.kanban
+.kanban__column
+.kanban__column--overloaded
+.kanban__card
+.kanban__card--dragging
+.kanban__warning
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Three columns display tasks by status
+- [ ] Tasks can be dragged between columns
+- [ ] Status persists to Supabase on drop
+- [ ] Dropping into "Doing" with 3+ tasks is blocked
+- [ ] Overload warning is displayed visually
+- [ ] No external drag-and-drop library

--- a/docs/requirements/performance.md
+++ b/docs/requirements/performance.md
@@ -1,0 +1,54 @@
+# Issue #10 — Performance
+
+## Objective
+
+Implement performance optimisations as defined in the non-functional requirements. These apply across all modules.
+
+## Reference
+
+- `docs/requirements.md` — Section 3.3
+
+---
+
+## Requirements
+
+### 1. Lazy load all route views
+
+Every route component must use dynamic import:
+
+```ts
+// ✅ Correct
+component: () => import('@/modules/kanban/views/KanbanView.vue')
+
+// ❌ Wrong
+import KanbanView from '@/modules/kanban/views/KanbanView.vue'
+```
+
+### 2. Code splitting per route
+
+Vite handles this automatically when dynamic imports are used. Each route produces a separate chunk in `dist/assets/`.
+
+### 3. Graph module — load only when accessed
+
+The graph module is the heaviest. It must never be included in the initial bundle. Verify in the build output that `GraphView` is in its own chunk.
+
+### 4. Avoid unnecessary re-renders
+
+- Prefer `computed` over methods for derived state
+- Use `shallowRef` for large collections that don't need deep reactivity
+- Avoid reactive objects in hot paths (drag events, canvas render loops)
+
+### 5. Drag interactions under 16ms
+
+- Use `requestAnimationFrame` for drag position updates
+- Never call Supabase inside a drag event — debounce position persistence to `dragend`
+
+---
+
+## Acceptance Criteria
+
+- [ ] All views are lazy loaded (verify with `pnpm build` output)
+- [ ] Graph module is a separate chunk
+- [ ] No blocking imports in `main.ts` or `router/index.ts`
+- [ ] Drag interactions are smooth at 60fps
+- [ ] Supabase calls are never inside drag event handlers

--- a/docs/requirements/projects.md
+++ b/docs/requirements/projects.md
@@ -1,0 +1,67 @@
+# Issue #4 — Projects Module
+
+## Objective
+
+Implement project management scoped to the authenticated user. Projects are the top-level container for tasks.
+
+## Reference
+
+- `docs/requirements.md` — Section 2.2
+- `supabase/migrations/20260217000001_create_schema.sql` — `projects` table
+
+---
+
+## Steps
+
+### 1. Types (`src/modules/projects/types/index.ts`)
+
+```ts
+interface Project {
+  id: string
+  user_id: string
+  name: string
+  created_at: string
+}
+
+type CreateProjectPayload = Pick<Project, 'name'>
+type UpdateProjectPayload = Pick<Project, 'id' | 'name'>
+```
+
+### 2. Projects service (`src/modules/projects/services/projects.service.ts`)
+
+```ts
+fetchProjects(): Promise<Project[]>
+createProject(payload: CreateProjectPayload): Promise<Project>
+updateProject(payload: UpdateProjectPayload): Promise<Project>
+deleteProject(id: string): Promise<void>
+```
+
+### 3. Projects composable (`src/modules/projects/composables/useProjects.ts`)
+
+```ts
+const { projects, loading, error, createProject, updateProject, deleteProject } = useProjects()
+```
+
+### 4. View (`src/modules/projects/views/ProjectsView.vue`)
+
+- List all projects for the authenticated user
+- Create new project (inline or modal)
+- Edit project name inline
+- Delete project with confirmation
+- Select active project (persisted in store)
+
+### 5. Store (`src/store/`)
+
+Global state for the active project — used by tasks, kanban, and graph modules.
+
+---
+
+## Acceptance Criteria
+
+- [ ] User can create a project
+- [ ] User can edit a project name
+- [ ] User can delete a project
+- [ ] Projects list only shows the authenticated user's projects
+- [ ] Active project selection is shared across modules
+- [ ] No Supabase calls outside the service layer
+- [ ] All types defined — no `any`

--- a/docs/requirements/tasks.md
+++ b/docs/requirements/tasks.md
@@ -1,0 +1,77 @@
+# Issue #5 — Tasks Module
+
+## Objective
+
+Implement task management with status tracking, energy levels, and impact scores. Tasks are the core data unit used by Kanban, Graph, and Focus modules.
+
+## Reference
+
+- `docs/requirements.md` — Section 2.3
+- `supabase/migrations/20260217000001_create_schema.sql` — `tasks` table
+
+---
+
+## Steps
+
+### 1. Types (`src/modules/tasks/types/index.ts`)
+
+```ts
+type TaskStatus = 'todo' | 'doing' | 'done'
+
+interface Task {
+  id: string
+  project_id: string
+  title: string
+  description: string | null
+  status: TaskStatus
+  energy_level: 1 | 2 | 3
+  impact_score: 1 | 2 | 3 | 4 | 5
+  position_x: number | null
+  position_y: number | null
+  created_at: string
+}
+
+type CreateTaskPayload = Pick<Task, 'project_id' | 'title' | 'description' | 'status' | 'energy_level' | 'impact_score'>
+type UpdateTaskPayload = Partial<Omit<Task, 'id' | 'project_id' | 'created_at'>> & { id: string }
+```
+
+### 2. Tasks service (`src/modules/tasks/services/tasks.service.ts`)
+
+```ts
+fetchTasks(projectId: string): Promise<Task[]>
+createTask(payload: CreateTaskPayload): Promise<Task>
+updateTask(payload: UpdateTaskPayload): Promise<Task>
+deleteTask(id: string): Promise<void>
+updateStatus(id: string, status: TaskStatus): Promise<Task>
+updatePosition(id: string, x: number, y: number): Promise<Task>
+```
+
+### 3. Tasks composable (`src/modules/tasks/composables/useTasks.ts`)
+
+```ts
+const { tasks, loading, error, createTask, updateTask, deleteTask } = useTasks(projectId)
+```
+
+### 4. Components
+
+| Component | Purpose |
+| --------- | ------- |
+| `TaskCard.vue` | Displays task title, status badge, energy and impact indicators |
+| `TaskForm.vue` | Create / edit form with all fields |
+
+### 5. Constraints
+
+- `energy_level`: 1–3 (enforced in DB + UI)
+- `impact_score`: 1–5 (enforced in DB + UI)
+- Max 3 tasks in `doing` status per project — enforced in UI, not DB
+
+---
+
+## Acceptance Criteria
+
+- [ ] User can create, edit, and delete tasks
+- [ ] Status, energy level, and impact score are assignable
+- [ ] Tasks are scoped to the active project
+- [ ] `position_x` / `position_y` update correctly for graph view
+- [ ] No Supabase calls outside the service layer
+- [ ] All types defined — no `any`

--- a/docs/requirements/ui-design-system.md
+++ b/docs/requirements/ui-design-system.md
@@ -1,0 +1,89 @@
+# Issue #9 — UI Design System
+
+## Objective
+
+Establish the base CSS3 + BEM design system used across all modules. Design tokens are sourced from the Stitch desktop atoms.
+
+## Reference
+
+- `docs/requirements.md` — Section 6
+- `stitch/design-system-desktop-atoms/` — source of truth for tokens
+- `src/styles/` — implementation
+
+---
+
+## Design Tokens
+
+Defined in `src/styles/variables.css`:
+
+| Token | Value | Usage |
+| ----- | ----- | ----- |
+| `--color-primary` | `#111111` | Text, borders |
+| `--color-surface` | `#ffffff` | Card backgrounds |
+| `--color-background` | `#f9fafb` | Page background |
+| `--color-status-active` | `#f3e8ff` | "Doing" status |
+| `--color-status-focus` | `#e0f2fe` | Focus mode accent |
+| `--color-status-done` | `#dcfce7` | "Done" status |
+| `--font-size-display` | `64px` | H1 / Display |
+| `--font-size-h2` | `32px` | Section titles |
+| `--font-size-h3` | `20px` | Card titles |
+| `--font-size-body` | `16px` | Body text |
+| `--space-xs` | `4px` | Atomic unit |
+| `--space-sm` | `8px` | Tight spacing |
+| `--space-md` | `16px` | Component gap |
+| `--space-lg` | `32px` | Section gap |
+| `--space-xl` | `64px` | Layout padding |
+| `--radius-md` | `12px` | Cards |
+| `--radius-lg` | `16px` | Modals, panels |
+| `--shadow-sm` | `0 1px 2px rgba(0,0,0,0.05)` | Subtle elevation |
+
+## BEM Patterns
+
+Every component follows strict BEM naming:
+
+```css
+/* Block */
+.task-card { }
+
+/* Elements */
+.task-card__title { }
+.task-card__meta { }
+.task-card__actions { }
+
+/* Modifiers */
+.task-card--doing { }
+.task-card--done { }
+.task-card--dragging { }
+```
+
+Rules:
+- One scoped `<style>` block per component
+- No utility classes, no inline styles
+- No Tailwind or any CSS framework
+
+## Shared Components
+
+Already scaffolded in `src/components/`:
+
+| Component | Purpose |
+| --------- | ------- |
+| `SectionHeader.vue` | Section divider with icon and title |
+| `TypographySample.vue` | Typography specimen |
+| `ColorSwatch.vue` | Color token display |
+| `StatusBadge.vue` | Status color tile |
+| `IconBox.vue` | Material icon in a box |
+| `SpacingBlock.vue` | Spacing visualisation |
+
+## Showcase
+
+Live at `/design-system` — see `src/modules/projects/views/DesignSystemView.vue`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] All design tokens defined in `variables.css`
+- [ ] Reset and base typography in `reset.css` / `base.css`
+- [ ] BEM naming consistent across all components
+- [ ] Design system showcase route works
+- [ ] No Tailwind or utility CSS installed


### PR DESCRIPTION
# docs: add requirement docs for all open issues

## Description

Creates a dedicated requirement document for each open issue (#3–#10), following the same pattern as `docs/requirements/project-scaffolding.md`. Each doc includes objective, step-by-step implementation guide, types, service API signatures, component breakdown, and acceptance criteria.

| File | Issue |
| ---- | ----- |
| `authentication.md` | #3 — Auth module |
| `projects.md` | #4 — Projects module |
| `tasks.md` | #5 — Tasks module |
| `kanban.md` | #6 — Kanban board |
| `graph.md` | #7 — Graph view |
| `focus-mode.md` | #8 — Focus mode |
| `ui-design-system.md` | #9 — UI design system |
| `performance.md` | #10 — Performance |

## Why?

Gives every future implementation a clear, self-contained spec to work from without having to cross-reference the main requirements doc and GitHub issues simultaneously.

## Screenshots (Before & After)

N/A — documentation only.

## How to test

- Open any file in `docs/requirements/` and verify it has objective, steps, and acceptance criteria

## Branch Information

- **Source Branch:** `docs/requirements`
- **Target Branch:** `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)