### PR TITLE
feat(kanban): add board with drag-drop and WIP limit

### DIFF
--- a/src/app/AppLayout.vue
+++ b/src/app/AppLayout.vue
@@ -187,7 +187,8 @@ async function handleSignOut(): Promise<void> {
 /* Main content */
 .app-layout__main {
   flex: 1;
-  overflow-y: auto;
-  overflow-x: hidden;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 </style>

--- a/src/modules/kanban/components/KanbanCard.vue
+++ b/src/modules/kanban/components/KanbanCard.vue
@@ -1,0 +1,237 @@
+<template>
+  <div
+    class="kcard"
+    :class="{
+      'kcard--featured': featured,
+      'kcard--done': task.status === 'done',
+      'kcard--dragging': isDragging,
+    }"
+    draggable="true"
+    @dragstart="onDragStart"
+    @dragend="onDragEnd"
+  >
+    <!-- Done card -->
+    <template v-if="task.status === 'done'">
+      <div class="kcard__done-row">
+        <span class="kcard__done-icon">check_circle</span>
+        <h3 class="kcard__done-title">{{ task.title }}</h3>
+      </div>
+    </template>
+
+    <!-- Regular / featured card -->
+    <template v-else>
+      <h3 class="kcard__title">{{ task.title }}</h3>
+      <p v-if="task.description" class="kcard__desc">{{ task.description }}</p>
+      <div class="kcard__actions">
+        <button class="kcard__btn" title="Edit" @click.stop="$emit('edit', task)">
+          <span class="material-symbols-outlined">edit</span>
+        </button>
+        <button
+          class="kcard__btn kcard__btn--danger"
+          title="Delete"
+          @click.stop="$emit('delete', task.id)"
+        >
+          <span class="material-symbols-outlined">delete</span>
+        </button>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { Task } from '@/modules/tasks/types'
+
+const props = defineProps<{
+  task: Task
+  featured?: boolean
+}>()
+
+const emit = defineEmits<{
+  edit: [task: Task]
+  delete: [id: string]
+  dragstart: [taskId: string]
+  dragend: []
+}>()
+
+const isDragging = ref(false)
+
+function onDragStart(e: Event): void {
+  // eslint-disable-next-line no-undef
+  const event = e as DragEvent
+  if (!event.dataTransfer) return
+  event.dataTransfer.setData('taskId', props.task.id)
+  event.dataTransfer.setData('fromStatus', props.task.status)
+  event.dataTransfer.effectAllowed = 'move'
+  isDragging.value = true
+  emit('dragstart', props.task.id)
+}
+
+function onDragEnd(): void {
+  isDragging.value = false
+  emit('dragend')
+}
+</script>
+
+<style scoped>
+.kcard {
+  background: var(--color-surface);
+  border: var(--border-width) solid transparent;
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
+  cursor: grab;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s,
+    transform 0.15s,
+    opacity 0.15s;
+  position: relative;
+}
+
+.kcard:hover {
+  border-color: var(--border-color);
+  box-shadow: var(--shadow-sm);
+}
+
+.kcard:active {
+  cursor: grabbing;
+}
+
+.kcard--dragging {
+  opacity: 0.4;
+}
+
+/* ── Featured (first doing card) ── */
+.kcard--featured {
+  background: var(--color-primary);
+  border-color: transparent;
+  padding: 2rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.kcard--featured:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.25);
+  border-color: transparent;
+}
+
+.kcard--featured .kcard__title {
+  color: var(--color-surface);
+  font-size: var(--font-size-h3);
+}
+
+.kcard--featured .kcard__desc {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.kcard--featured .kcard__btn {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.kcard--featured .kcard__btn:hover {
+  color: var(--color-surface);
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+/* ── Done card ── */
+.kcard--done {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.kcard--done:hover {
+  opacity: 1;
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.kcard__done-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.kcard__done-icon {
+  font-family: 'Material Symbols Outlined';
+  font-size: 18px;
+  color: #22c55e;
+  font-variation-settings: 'FILL' 1;
+  flex-shrink: 0;
+}
+
+.kcard__done-title {
+  font-size: var(--font-size-body);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-gray-500);
+  text-decoration: line-through;
+  text-decoration-color: var(--color-gray-300);
+}
+
+/* ── Regular card content ── */
+.kcard__title {
+  font-size: var(--font-size-body);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-primary);
+  line-height: var(--leading-snug);
+  margin-bottom: var(--space-xs);
+}
+
+.kcard__desc {
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-500);
+  line-height: var(--leading-relaxed);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ── Actions ── */
+.kcard__actions {
+  display: flex;
+  gap: var(--space-xs);
+  margin-top: var(--space-sm);
+  padding-top: var(--space-sm);
+  border-top: var(--border-width) solid var(--border-color);
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.kcard--featured .kcard__actions {
+  border-top-color: rgba(255, 255, 255, 0.1);
+}
+
+.kcard:hover .kcard__actions {
+  opacity: 1;
+}
+
+.kcard__btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: none;
+  border-radius: var(--radius-md);
+  color: var(--color-gray-400);
+  cursor: pointer;
+  transition:
+    color 0.15s,
+    background-color 0.15s;
+}
+
+.kcard__btn:hover {
+  color: var(--color-primary);
+  background-color: var(--color-background);
+}
+
+.kcard__btn--danger:hover {
+  color: #dc2626;
+  background-color: #fef2f2;
+}
+
+.kcard__btn .material-symbols-outlined {
+  font-size: 15px;
+}
+</style>

--- a/src/modules/kanban/components/KanbanColumn.vue
+++ b/src/modules/kanban/components/KanbanColumn.vue
@@ -1,0 +1,344 @@
+<template>
+  <section
+    class="kcol"
+    :class="{
+      'kcol--doing': status === 'doing',
+      'kcol--done': status === 'done',
+      'kcol--dragover': isDragOver,
+    }"
+    @dragover.prevent="onDragOver"
+    @dragenter.prevent="onDragEnter"
+    @dragleave="onDragLeave"
+    @drop.prevent="onDrop"
+  >
+    <!-- Column header -->
+    <div class="kcol__header">
+      <div class="kcol__header-left">
+        <h2 class="kcol__title">{{ label }}</h2>
+        <span v-if="status === 'doing'" class="kcol__pulse"></span>
+        <span v-else class="kcol__count">{{ tasks.length }}</span>
+      </div>
+
+      <!-- WIP badge (doing column only) -->
+      <div
+        v-if="status === 'doing'"
+        class="kcol__wip"
+        :class="{
+          'kcol__wip--warn': tasks.length >= 2 && tasks.length < WIP_LIMIT,
+          'kcol__wip--full': tasks.length >= WIP_LIMIT,
+        }"
+      >
+        <span v-if="tasks.length >= WIP_LIMIT" class="kcol__wip-icon">warning</span>
+        <span class="kcol__wip-text">
+          {{
+            tasks.length >= WIP_LIMIT ? 'Limit Reached' : tasks.length >= 2 ? 'Limit Near' : 'WIP'
+          }}
+        </span>
+        <span class="kcol__wip-ratio">{{ tasks.length }} / {{ WIP_LIMIT }}</span>
+      </div>
+    </div>
+
+    <!-- Cards -->
+    <div class="kcol__body">
+      <KanbanCard
+        v-for="(task, i) in tasks"
+        :key="task.id"
+        :task="task"
+        :featured="status === 'doing' && i === 0"
+        @edit="$emit('edit', $event)"
+        @delete="$emit('delete', $event)"
+        @dragstart="$emit('dragstart', $event)"
+        @dragend="$emit('dragend')"
+      />
+
+      <!-- Drop placeholder (doing column, when dragging) -->
+      <div
+        v-if="status === 'doing' && isDraggingActive && tasks.length < WIP_LIMIT"
+        class="kcol__drop-zone"
+      >
+        <span class="material-symbols-outlined">ads_click</span>
+        <span>Drag here to focus</span>
+      </div>
+
+      <!-- Add task button (todo column) -->
+      <button v-if="status === 'todo'" class="kcol__add-btn" @click="$emit('add-task')">
+        <span class="material-symbols-outlined">add</span>
+        Add Task
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import KanbanCard from './KanbanCard.vue'
+import type { Task, TaskStatus } from '@/modules/tasks/types'
+
+const WIP_LIMIT = 3
+
+const props = defineProps<{
+  status: TaskStatus
+  label: string
+  tasks: Task[]
+  isDraggingActive: boolean
+}>()
+
+const emit = defineEmits<{
+  drop: [taskId: string, newStatus: TaskStatus]
+  edit: [task: Task]
+  delete: [id: string]
+  'add-task': []
+  dragstart: [taskId: string]
+  dragend: []
+}>()
+
+const isDragOver = ref(false)
+let dragEnterCount = 0
+
+function onDragEnter(): void {
+  dragEnterCount++
+  isDragOver.value = true
+}
+
+function onDragLeave(): void {
+  dragEnterCount--
+  if (dragEnterCount <= 0) {
+    dragEnterCount = 0
+    isDragOver.value = false
+  }
+}
+
+function onDragOver(e: Event): void {
+  // eslint-disable-next-line no-undef
+  const event = e as DragEvent
+  if (!event.dataTransfer) return
+  event.dataTransfer.dropEffect = 'move'
+}
+
+function onDrop(e: Event): void {
+  isDragOver.value = false
+  dragEnterCount = 0
+
+  // eslint-disable-next-line no-undef
+  const event = e as DragEvent
+  if (!event.dataTransfer) return
+  const taskId = event.dataTransfer.getData('taskId')
+  const fromStatus = event.dataTransfer.getData('fromStatus')
+
+  if (!taskId || fromStatus === props.status) return
+  if (props.status === 'doing' && props.tasks.length >= WIP_LIMIT) return
+
+  emit('drop', taskId, props.status)
+}
+</script>
+
+<style scoped>
+.kcol {
+  display: flex;
+  flex-direction: column;
+  width: 340px;
+  min-width: 300px;
+  max-width: 380px;
+  height: 100%;
+  border-radius: var(--radius-lg);
+  background: var(--color-background);
+  border: var(--border-width) solid var(--border-color);
+  flex-shrink: 0;
+  transition: border-color 0.2s;
+}
+
+/* Doing column: featured, wider */
+.kcol--doing {
+  flex: 1;
+  min-width: 360px;
+  max-width: 480px;
+  background: var(--color-surface);
+  border-width: 2px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.06);
+}
+
+/* Done column: slightly faded */
+.kcol--done {
+  opacity: 0.85;
+}
+
+/* Drag-over highlight */
+.kcol--dragover {
+  border-color: var(--color-primary);
+}
+
+/* ── Header ── */
+.kcol__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.25rem 0.75rem;
+  flex-shrink: 0;
+}
+
+.kcol--doing .kcol__header {
+  border-bottom: var(--border-width) solid var(--border-color);
+  padding-bottom: 1rem;
+  margin-bottom: 0;
+}
+
+.kcol__header-left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.kcol__title {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-gray-500);
+}
+
+.kcol--doing .kcol__title {
+  color: var(--color-primary);
+  font-size: var(--font-size-sm);
+}
+
+.kcol__count {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  background: var(--color-surface);
+  color: var(--color-gray-600);
+  padding: 1px 6px;
+  border-radius: 4px;
+  border: var(--border-width) solid var(--border-color);
+}
+
+.kcol__pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background: #22c55e;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+/* ── WIP badge ── */
+.kcol__wip {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  background: var(--color-background);
+  border: var(--border-width) solid var(--border-color);
+  color: var(--color-gray-500);
+}
+
+.kcol__wip--warn {
+  background: #fff7ed;
+  border-color: #fed7aa;
+  color: #c2410c;
+}
+
+.kcol__wip--full {
+  background: #fef2f2;
+  border-color: #fecaca;
+  color: #dc2626;
+}
+
+.kcol__wip-icon {
+  font-family: 'Material Symbols Outlined';
+  font-size: 13px;
+  font-variation-settings: 'FILL' 0;
+}
+
+.kcol__wip-text {
+  font-size: 10px;
+  letter-spacing: 0.05em;
+}
+
+.kcol__wip-ratio {
+  font-family: monospace;
+  font-size: var(--font-size-xs);
+}
+
+/* ── Body ── */
+.kcol__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  scrollbar-width: none;
+}
+
+.kcol__body::-webkit-scrollbar {
+  display: none;
+}
+
+.kcol--doing .kcol__body {
+  padding: 1rem;
+  gap: 1.25rem;
+  background: color-mix(in srgb, var(--color-background) 50%, transparent);
+}
+
+/* ── Drop zone placeholder ── */
+.kcol__drop-zone {
+  height: 120px;
+  border: 2px dashed var(--border-color);
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  color: var(--color-gray-300);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+}
+
+.kcol__drop-zone .material-symbols-outlined {
+  font-size: 28px;
+  opacity: 0.5;
+}
+
+/* ── Add task button ── */
+.kcol__add-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  width: 100%;
+  padding: 0.75rem;
+  border: 2px dashed var(--color-gray-200);
+  border-radius: var(--radius-lg);
+  background: none;
+  color: var(--color-gray-400);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition:
+    border-color 0.2s,
+    color 0.2s;
+  font-family: var(--font-family);
+}
+
+.kcol__add-btn:hover {
+  border-color: var(--color-gray-400);
+  color: var(--color-gray-600);
+}
+
+.kcol__add-btn .material-symbols-outlined {
+  font-size: 18px;
+}
+</style>

--- a/src/modules/kanban/views/KanbanView.vue
+++ b/src/modules/kanban/views/KanbanView.vue
@@ -1,0 +1,405 @@
+<template>
+  <div class="kanban-wrap">
+    <template v-if="loading">
+      <div class="kanban-pick">
+        <p class="kanban-pick__sub">Loading...</p>
+      </div>
+    </template>
+
+    <template v-else-if="!selectedProject">
+      <div class="kanban-pick">
+        <h1 class="kanban-pick__title">Project not found</h1>
+        <p class="kanban-pick__sub">
+          Select a project from the <RouterLink to="/">dashboard</RouterLink>.
+        </p>
+      </div>
+    </template>
+
+    <template v-else>
+      <header class="kanban-header">
+        <div class="kanban-header__left">
+          <RouterLink class="kanban-header__back" :to="`/project/${toSlug(selectedProject.name)}`">
+            <span class="material-symbols-outlined">arrow_back</span>
+          </RouterLink>
+          <div>
+            <h2 class="kanban-header__title">{{ selectedProject.name }}</h2>
+            <p class="kanban-header__meta">{{ totalCount }} tasks · {{ doneCount }} done</p>
+          </div>
+        </div>
+        <button class="kanban-header__new-btn" @click="openForm('todo')">
+          <span class="material-symbols-outlined">add</span>
+          New Task
+        </button>
+      </header>
+
+      <div class="kanban-board">
+        <KanbanColumn
+          v-for="col in COLUMNS"
+          :key="col.status"
+          :status="col.status"
+          :label="col.label"
+          :tasks="tasksByStatus[col.status]"
+          :is-dragging-active="draggingTaskId !== null"
+          @drop="handleDrop"
+          @edit="startEdit"
+          @delete="handleDelete"
+          @dragstart="draggingTaskId = $event"
+          @dragend="draggingTaskId = null"
+          @add-task="openForm(col.status)"
+        />
+      </div>
+
+      <!-- WIP overload banner -->
+      <Transition name="fade">
+        <div v-if="wipOverload" class="kanban-wip-banner">
+          Cognitive overload: move a task to Done before adding more to Doing.
+        </div>
+      </Transition>
+
+      <!-- Task form -->
+      <TaskForm
+        v-if="showForm"
+        :task="editingTask ?? undefined"
+        :project-id="selectedProject.id"
+        :loading="saving"
+        :error="formError"
+        @submit="handleSubmit"
+        @cancel="closeForm"
+      />
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { useProjects } from '@/modules/projects/composables/useProjects'
+import {
+  fetchTasks,
+  updateTask,
+  deleteTask as deleteTaskService,
+  createTask,
+} from '@/modules/tasks/services/tasks.service'
+import KanbanColumn from '@/modules/kanban/components/KanbanColumn.vue'
+import TaskForm from '@/modules/tasks/components/TaskForm.vue'
+import type { Project } from '@/modules/projects/types'
+import type { Task, TaskStatus } from '@/modules/tasks/types'
+
+const WIP_LIMIT = 3
+
+const COLUMNS: { status: TaskStatus; label: string }[] = [
+  { status: 'todo', label: 'To Do' },
+  { status: 'doing', label: 'Doing' },
+  { status: 'done', label: 'Done' },
+]
+
+const route = useRoute()
+const { projects, fetchProjects } = useProjects()
+
+const selectedProject = ref<Project | null>(null)
+const tasks = ref<Task[]>([])
+const loading = ref(false)
+const saving = ref(false)
+const formError = ref<string | undefined>(undefined)
+
+const showForm = ref(false)
+const editingTask = ref<Task | null>(null)
+const newTaskStatus = ref<TaskStatus>('todo')
+const draggingTaskId = ref<string | null>(null)
+
+function toSlug(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, '-')
+}
+
+onMounted(async () => {
+  loading.value = true
+  if (projects.value.length === 0) await fetchProjects()
+  await loadProject()
+  loading.value = false
+})
+
+watch(() => route.params.slug, loadProject)
+
+async function loadProject(): Promise<void> {
+  const slug = route.params.slug as string
+  const project = projects.value.find((p) => toSlug(p.name) === slug)
+  if (!project) return
+  selectedProject.value = project
+  const result = await fetchTasks(project.id)
+  if (result.data) tasks.value = result.data
+}
+
+const tasksByStatus = computed<Record<TaskStatus, Task[]>>(() => ({
+  todo: tasks.value.filter((t) => t.status === 'todo'),
+  doing: tasks.value.filter((t) => t.status === 'doing'),
+  done: tasks.value.filter((t) => t.status === 'done'),
+}))
+
+const totalCount = computed(() => tasks.value.length)
+const doneCount = computed(() => tasksByStatus.value.done.length)
+const wipOverload = computed(() => tasksByStatus.value.doing.length >= WIP_LIMIT)
+
+async function handleDrop(taskId: string, newStatus: TaskStatus): Promise<void> {
+  if (newStatus === 'doing' && tasksByStatus.value.doing.length >= WIP_LIMIT) return
+
+  const result = await updateTask({ id: taskId, status: newStatus })
+  if (result.data) {
+    const idx = tasks.value.findIndex((t) => t.id === taskId)
+    if (idx !== -1) tasks.value[idx] = result.data
+  }
+}
+
+function openForm(status: TaskStatus): void {
+  newTaskStatus.value = status
+  editingTask.value = null
+  showForm.value = true
+}
+
+function startEdit(task: Task): void {
+  editingTask.value = task
+  showForm.value = true
+}
+
+function closeForm(): void {
+  showForm.value = false
+  editingTask.value = null
+  formError.value = undefined
+}
+
+async function handleSubmit(payload: {
+  title: string
+  description: string | null
+  status: TaskStatus
+}): Promise<void> {
+  if (!selectedProject.value) return
+  saving.value = true
+  formError.value = undefined
+
+  if (editingTask.value) {
+    const taskId = editingTask.value.id
+    const result = await updateTask({ id: taskId, ...payload })
+    if (result.error) {
+      formError.value = result.error.message
+      saving.value = false
+      return
+    }
+    if (result.data) {
+      const idx = tasks.value.findIndex((t) => t.id === taskId)
+      if (idx !== -1) tasks.value[idx] = result.data
+    }
+  } else {
+    if (payload.status === 'doing' && tasksByStatus.value.doing.length >= WIP_LIMIT) {
+      formError.value = 'WIP limit reached: max 3 tasks in Doing.'
+      saving.value = false
+      return
+    }
+    const result = await createTask({ project_id: selectedProject.value.id, ...payload })
+    if (result.error) {
+      formError.value = result.error.message
+      saving.value = false
+      return
+    }
+    if (result.data) tasks.value.push(result.data)
+  }
+
+  saving.value = false
+  closeForm()
+}
+
+async function handleDelete(id: string): Promise<void> {
+  if (!confirm('Delete this task?')) return
+  await deleteTaskService(id)
+  tasks.value = tasks.value.filter((t) => t.id !== id)
+}
+</script>
+
+<style scoped>
+/* ── Wrapper: fills main content area ── */
+.kanban-wrap {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* ── Project picker ── */
+.kanban-pick {
+  padding: var(--space-xl);
+  max-width: 860px;
+}
+
+.kanban-pick__title {
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  font-weight: 900;
+  letter-spacing: -0.05em;
+  line-height: 0.9;
+  color: var(--color-primary);
+  margin-bottom: var(--space-md);
+}
+
+.kanban-pick__sub {
+  font-size: var(--font-size-body);
+  color: var(--color-gray-500);
+  margin-bottom: var(--space-lg);
+}
+
+.kanban-pick__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--space-md);
+}
+
+.kanban-pick__card {
+  aspect-ratio: 1;
+  padding: var(--space-lg);
+  border: var(--border-width) solid var(--color-primary);
+  border-radius: var(--radius-md);
+  background: transparent;
+  font-size: var(--font-size-h3);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-family);
+  transition:
+    background-color 0.3s,
+    color 0.3s;
+}
+
+.kanban-pick__card:hover {
+  background-color: var(--color-primary);
+  color: var(--color-surface);
+}
+
+.kanban-pick__empty {
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-400);
+  margin-top: var(--space-lg);
+}
+
+.kanban-pick__empty a {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+/* ── Board header ── */
+.kanban-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
+  border-bottom: var(--border-width) solid var(--border-color);
+  background: var(--color-surface);
+  flex-shrink: 0;
+}
+
+.kanban-header__left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.kanban-header__back {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: none;
+  border-radius: var(--radius-md);
+  color: var(--color-gray-400);
+  cursor: pointer;
+  transition:
+    color 0.15s,
+    background-color 0.15s;
+}
+
+.kanban-header__back:hover {
+  color: var(--color-primary);
+  background-color: var(--color-background);
+}
+
+.kanban-header__back .material-symbols-outlined {
+  font-size: 20px;
+}
+
+.kanban-header__title {
+  font-size: var(--font-size-h3);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-primary);
+}
+
+.kanban-header__meta {
+  font-size: var(--font-size-xs);
+  color: var(--color-gray-400);
+  font-family: monospace;
+  margin-top: 2px;
+}
+
+.kanban-header__new-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-md);
+  background-color: var(--color-primary);
+  color: var(--color-surface);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: opacity 0.15s;
+  font-family: var(--font-family);
+}
+
+.kanban-header__new-btn:hover {
+  opacity: 0.85;
+}
+
+.kanban-header__new-btn .material-symbols-outlined {
+  font-size: 18px;
+}
+
+/* ── Board ── */
+.kanban-board {
+  flex: 1;
+  display: flex;
+  gap: 1.5rem;
+  padding: 1.5rem 2rem;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+/* ── WIP overload banner ── */
+.kanban-wip-banner {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #dc2626;
+  color: white;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius-full);
+  box-shadow: 0 4px 20px rgba(220, 38, 38, 0.4);
+  z-index: 200;
+  white-space: nowrap;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition:
+    opacity 0.3s,
+    transform 0.3s;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(8px);
+}
+</style>

--- a/src/modules/projects/views/ProjectsView.vue
+++ b/src/modules/projects/views/ProjectsView.vue
@@ -162,6 +162,8 @@ watch(showForm, async (val) => {
 .projects {
   padding: var(--space-xl);
   max-width: 720px;
+  overflow-y: auto;
+  height: 100%;
 }
 
 .projects__header {

--- a/src/modules/projects/views/SingleProjectView.vue
+++ b/src/modules/projects/views/SingleProjectView.vue
@@ -14,10 +14,21 @@
       <!-- Progress ring -->
       <div class="project__progress">
         <svg class="project__progress-ring" viewBox="0 0 112 112">
-          <circle cx="56" cy="56" r="48" fill="none" stroke="var(--border-color)" stroke-width="1.5" />
           <circle
-            cx="56" cy="56" r="48" fill="none"
-            stroke="var(--color-primary)" stroke-width="1.5"
+            cx="56"
+            cy="56"
+            r="48"
+            fill="none"
+            stroke="var(--border-color)"
+            stroke-width="1.5"
+          />
+          <circle
+            cx="56"
+            cy="56"
+            r="48"
+            fill="none"
+            stroke="var(--color-primary)"
+            stroke-width="1.5"
             stroke-linecap="round"
             :stroke-dasharray="CIRCUMFERENCE"
             :stroke-dashoffset="dashOffset"
@@ -63,7 +74,11 @@
               <button class="project__task-btn" title="Edit" @click="startEdit(task)">
                 <span class="material-symbols-outlined">edit</span>
               </button>
-              <button class="project__task-btn project__task-btn--danger" title="Delete" @click="handleDelete(task.id)">
+              <button
+                class="project__task-btn project__task-btn--danger"
+                title="Delete"
+                @click="handleDelete(task.id)"
+              >
                 <span class="material-symbols-outlined">delete</span>
               </button>
             </div>
@@ -89,6 +104,21 @@
               <p class="project__stat-number">{{ doneTasks.length }}</p>
               <p class="project__stat-meta">Done</p>
             </div>
+          </div>
+        </div>
+
+        <!-- View links -->
+        <div class="project__sidebar-section">
+          <h3 class="project__sidebar-label">Views</h3>
+          <div class="project__views">
+            <RouterLink class="project__view-link" :to="`/project/${toSlug(project.name)}/board`">
+              <span class="material-symbols-outlined">view_kanban</span>
+              Board
+            </RouterLink>
+            <RouterLink class="project__view-link" :to="`/project/${toSlug(project.name)}/tasks`">
+              <span class="material-symbols-outlined">task_alt</span>
+              List
+            </RouterLink>
           </div>
         </div>
 
@@ -134,7 +164,8 @@ import type { Task, TaskStatus } from '@/modules/tasks/types'
 
 const route = useRoute()
 const { projects, fetchProjects } = useProjects()
-const { tasks, loading, error, fetchTasks, createTask, updateTask, deleteTask, updateStatus } = useTasks()
+const { tasks, loading, error, fetchTasks, createTask, updateTask, deleteTask, updateStatus } =
+  useTasks()
 
 const project = ref<Project | null>(null)
 const showForm = ref(false)
@@ -203,6 +234,8 @@ async function handleSubmit(payload: {
 .project {
   padding: var(--space-xl);
   max-width: 1100px;
+  overflow-y: auto;
+  height: 100%;
 }
 
 /* ── Header ── */
@@ -419,7 +452,9 @@ async function handleSubmit(payload: {
   border-radius: var(--radius-md);
   color: var(--color-gray-400);
   cursor: pointer;
-  transition: color 0.15s, background-color 0.15s;
+  transition:
+    color 0.15s,
+    background-color 0.15s;
 }
 
 .project__task-btn:hover {
@@ -484,6 +519,37 @@ async function handleSubmit(payload: {
   letter-spacing: 0.2em;
   text-transform: uppercase;
   color: color-mix(in srgb, var(--color-primary) 35%, transparent);
+}
+
+/* ── View links ── */
+.project__views {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.project__view-link {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-md);
+  color: var(--color-gray-500);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  text-decoration: none;
+  transition:
+    background-color 0.15s,
+    color 0.15s;
+}
+
+.project__view-link:hover {
+  background-color: var(--color-background);
+  color: var(--color-primary);
+}
+
+.project__view-link .material-symbols-outlined {
+  font-size: 20px;
 }
 
 /* ── Done list ── */

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -29,9 +29,19 @@ const routes: RouteRecordRaw[] = [
         component: () => import('@/modules/projects/views/ProjectsView.vue'),
       },
       {
-        path: 'projects/:slug',
+        path: 'project/:slug',
         name: 'project',
         component: () => import('@/modules/projects/views/SingleProjectView.vue'),
+      },
+      {
+        path: 'project/:slug/board',
+        name: 'project-board',
+        component: () => import('@/modules/kanban/views/KanbanView.vue'),
+      },
+      {
+        path: 'project/:slug/tasks',
+        name: 'project-tasks',
+        component: () => import('@/modules/tasks/views/TasksView.vue'),
       },
       {
         path: 'tasks',


### PR DESCRIPTION
# feat: add kanban board with drag-drop and WIP limit

## Description

Added a full-page Kanban board with drag-and-drop functionality and WIP (Work In Progress) limit enforcement. Also refactored routes to be project-based (`/project/:slug/board` and `/project/:slug/tasks`).

## Why?

The POC requires a Kanban view for managing tasks with visual WIP limits. Project-based routes provide clean, bookmarkable URLs for each project's board and task list.

## Changes

- **KanbanView**: Full-page Kanban board with 3 columns (To Do, Doing, Done)
- **KanbanColumn**: Column component with drop zones, WIP badges
- **KanbanCard**: Draggable task cards with featured/regular/done states
- **Router**: New routes `/project/:slug/board` and `/project/:slug/tasks`
- **TasksView**: Supports both single-project and all-projects views
- **SingleProjectView**: Added sidebar links to Board and List views

## Screenshots (Before & After)

| Before | After |
|--------|-------|
| N/A | Kanban board with drag-drop |

## How to test

- Navigate to a project: `/project/portfolio`
- Click "Board" in sidebar → opens full-page Kanban
- Drag tasks between columns
- Verify WIP limit (max 3 in "Doing") is enforced
- Try `/project/portfolio/tasks` for task list view

## Branch Information

- **Source Branch:** `feat/6-kanban-board-columns-drag-and-drop-wip-limit`
- **Target Branch:** `main`