### PR TITLE
feat(focus): add focus mode with full-screen task view

### DIFF
--- a/src/modules/focus/views/FocusView.vue
+++ b/src/modules/focus/views/FocusView.vue
@@ -1,0 +1,418 @@
+<template>
+  <div class="focus">
+    <!-- Header -->
+    <header class="focus__header">
+      <div class="focus__logo">
+        <span class="focus__logo-icon">keyboard_command_key</span>
+        <span class="focus__logo-text">Focus Mode</span>
+      </div>
+      <button class="focus__exit" @click="handleExit">
+        <span>Exit</span>
+        <span class="material-symbols-outlined">close</span>
+      </button>
+    </header>
+
+    <!-- Main content -->
+    <main class="focus__main">
+      <div v-if="loading" class="focus__loading">Loading...</div>
+
+      <div v-else-if="!task" class="focus__not-found">
+        <p>Task not found</p>
+        <RouterLink to="/">Go to Projects</RouterLink>
+      </div>
+
+      <template v-else>
+        <div class="focus__content">
+          <!-- Status indicator -->
+          <div class="focus__status">
+            <span class="focus__status-dot"></span>
+            <span class="focus__status-text">Focusing...</span>
+          </div>
+
+          <!-- Task -->
+          <div class="focus__task">
+            <h1 class="focus__task-title">{{ task.title }}</h1>
+            <p v-if="task.description" class="focus__task-desc">{{ task.description }}</p>
+          </div>
+
+          <!-- Actions -->
+          <div class="focus__actions">
+            <button class="focus__complete" @click="handleComplete">
+              <span class="material-symbols-outlined">check_circle</span>
+              <span>Mark as Completed</span>
+            </button>
+            <div class="focus__shortcut">
+              <kbd>ESC</kbd>
+              <span>to exit</span>
+            </div>
+          </div>
+        </div>
+      </template>
+    </main>
+
+    <!-- Footer -->
+    <footer class="focus__footer">
+      <div class="focus__footer-item">
+        <span class="material-symbols-outlined">music_note</span>
+        <span>Deep Focus</span>
+      </div>
+      <div class="focus__footer-item">
+        <span class="material-symbols-outlined">notifications_off</span>
+        <span>Do Not Disturb</span>
+      </div>
+    </footer>
+
+    <!-- Ambient glow -->
+    <div class="focus__glow focus__glow--left"></div>
+    <div class="focus__glow focus__glow--right"></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { fetchTask, updateStatus } from '@/modules/tasks/services/tasks.service'
+import type { Task } from '@/modules/tasks/types'
+
+const route = useRoute()
+const router = useRouter()
+
+const task = ref<Task | null>(null)
+const loading = ref(true)
+
+const taskId = route.params.taskId as string
+
+onMounted(async () => {
+  const result = await fetchTask(taskId)
+  if (result.data) {
+    task.value = result.data
+  }
+  loading.value = false
+})
+
+function handleExit(): void {
+  router.back()
+}
+
+async function handleComplete(): Promise<void> {
+  if (!task.value) return
+  await updateStatus(task.value.id, 'done')
+  router.back()
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function handleKeydown(e: any): void {
+  if (e.key === 'Escape') {
+    handleExit()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('keydown', handleKeydown)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleKeydown)
+})
+</script>
+
+<style scoped>
+.focus {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at center, #fafafa 0%, #f0f0f0 100%);
+  display: flex;
+  flex-direction: column;
+  z-index: 1000;
+}
+
+/* Header */
+.focus__header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  padding: 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0;
+  transition: opacity 0.5s;
+}
+
+.focus:hover .focus__header {
+  opacity: 1;
+}
+
+.focus__logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.focus__logo-icon {
+  font-family: 'Material Symbols Outlined';
+  font-size: 18px;
+  color: var(--color-gray-400);
+}
+
+.focus__logo-text {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--color-gray-400);
+}
+
+.focus__exit {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  background: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.focus__exit:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.focus__exit span:first-child {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--color-gray-500);
+}
+
+.focus__exit .material-symbols-outlined {
+  font-size: 20px;
+  color: var(--color-gray-500);
+}
+
+/* Main */
+.focus__main {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.focus__loading,
+.focus__not-found {
+  text-align: center;
+  color: var(--color-gray-400);
+}
+
+.focus__not-found a {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.focus__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 720px;
+  animation: fadeInUp 0.8s ease-out;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Status */
+.focus__status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+}
+
+.focus__status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.focus__status-text {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--color-gray-400);
+}
+
+/* Task */
+.focus__task {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.focus__task-title {
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+  color: var(--color-primary);
+  margin-bottom: 1rem;
+}
+
+.focus__task-desc {
+  font-size: var(--font-size-lg);
+  font-weight: 400;
+  color: var(--color-gray-400);
+  max-width: 480px;
+  line-height: 1.6;
+}
+
+/* Actions */
+.focus__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.focus__complete {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 2rem;
+  background: var(--color-primary);
+  color: var(--color-surface);
+  border: none;
+  border-radius: var(--radius-lg);
+  font-size: var(--font-size-body);
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    transform 0.15s,
+    opacity 0.15s;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+}
+
+.focus__complete:hover {
+  transform: scale(1.02);
+  opacity: 0.9;
+}
+
+.focus__complete:active {
+  transform: scale(0.98);
+}
+
+.focus__complete .material-symbols-outlined {
+  font-size: 22px;
+  transition: transform 0.2s;
+}
+
+.focus__complete:hover .material-symbols-outlined {
+  transform: rotate(12deg);
+}
+
+.focus__shortcut {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-gray-300);
+  padding: 1rem 0;
+}
+
+.focus__shortcut kbd {
+  padding: 0.25rem 0.5rem;
+  background: rgba(0, 0, 0, 0.05);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  font-family: var(--font-family);
+}
+
+.focus__shortcut span {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+/* Footer */
+.focus__footer {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 2rem;
+  display: flex;
+  justify-content: center;
+  gap: 3rem;
+  opacity: 0;
+  transition: opacity 0.7s;
+}
+
+.focus:hover .focus__footer {
+  opacity: 1;
+}
+
+.focus__footer-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--color-gray-300);
+}
+
+.focus__footer-item .material-symbols-outlined {
+  font-size: 16px;
+}
+
+/* Glow effects */
+.focus__glow {
+  position: absolute;
+  top: 50%;
+  width: 200px;
+  height: 300px;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 50%;
+  filter: blur(80px);
+  pointer-events: none;
+}
+
+.focus__glow--left {
+  left: 0;
+  transform: translateY(-50%);
+}
+
+.focus__glow--right {
+  right: 0;
+  bottom: 0;
+  top: auto;
+  transform: none;
+}
+</style>

--- a/src/modules/kanban/components/KanbanCard.vue
+++ b/src/modules/kanban/components/KanbanCard.vue
@@ -23,6 +23,14 @@
       <h3 class="kcard__title">{{ task.title }}</h3>
       <p v-if="task.description" class="kcard__desc">{{ task.description }}</p>
       <div class="kcard__actions">
+        <button
+          v-if="featured"
+          class="kcard__btn kcard__btn--focus"
+          title="Focus"
+          @click.stop="$emit('focus', task)"
+        >
+          <span class="material-symbols-outlined">center_focus_strong</span>
+        </button>
         <button class="kcard__btn" title="Edit" @click.stop="$emit('edit', task)">
           <span class="material-symbols-outlined">edit</span>
         </button>
@@ -52,6 +60,7 @@ const emit = defineEmits<{
   delete: [id: string]
   dragstart: [taskId: string]
   dragend: []
+  focus: [task: Task]
 }>()
 
 const isDragging = ref(false)
@@ -229,6 +238,11 @@ function onDragEnd(): void {
 .kcard__btn--danger:hover {
   color: #dc2626;
   background-color: #fef2f2;
+}
+
+.kcard__btn--focus:hover {
+  color: var(--color-primary);
+  background-color: var(--color-background);
 }
 
 .kcard__btn .material-symbols-outlined {

--- a/src/modules/kanban/components/KanbanColumn.vue
+++ b/src/modules/kanban/components/KanbanColumn.vue
@@ -49,6 +49,7 @@
         @delete="$emit('delete', $event)"
         @dragstart="$emit('dragstart', $event)"
         @dragend="$emit('dragend')"
+        @focus="$emit('focus', $event)"
       />
 
       <!-- Drop placeholder (doing column, when dragging) -->
@@ -90,6 +91,7 @@ const emit = defineEmits<{
   'add-task': []
   dragstart: [taskId: string]
   dragend: []
+  focus: [task: Task]
 }>()
 
 const isDragOver = ref(false)

--- a/src/modules/kanban/views/KanbanView.vue
+++ b/src/modules/kanban/views/KanbanView.vue
@@ -46,6 +46,7 @@
           @dragstart="draggingTaskId = $event"
           @dragend="draggingTaskId = null"
           @add-task="openForm(col.status)"
+          @focus="goToFocus"
         />
       </div>
 
@@ -72,7 +73,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useProjects } from '@/modules/projects/composables/useProjects'
 import {
   fetchTasks,
@@ -94,6 +95,7 @@ const COLUMNS: { status: TaskStatus; label: string }[] = [
 ]
 
 const route = useRoute()
+const router = useRouter()
 const { projects, fetchProjects } = useProjects()
 
 const selectedProject = ref<Project | null>(null)
@@ -158,6 +160,10 @@ function openForm(status: TaskStatus): void {
 function startEdit(task: Task): void {
   editingTask.value = task
   showForm.value = true
+}
+
+function goToFocus(task: Task): void {
+  router.push(`/focus/${task.id}`)
 }
 
 function closeForm(): void {

--- a/src/modules/tasks/services/tasks.service.ts
+++ b/src/modules/tasks/services/tasks.service.ts
@@ -19,6 +19,14 @@ export async function fetchTasks(projectId: string): Promise<TasksResult<Task[]>
   return { data: data as Task[], error: null }
 }
 
+export async function fetchTask(id: string): Promise<TasksResult<Task>> {
+  const { data, error } = await supabase.from('tasks').select('*').eq('id', id).single()
+
+  if (error) return { data: null, error: { message: error.message } }
+
+  return { data: data as Task, error: null }
+}
+
 export async function fetchAllTasks(): Promise<TasksResult<Task[]>> {
   const { data, error } = await supabase
     .from('tasks')
@@ -41,12 +49,7 @@ export async function createTask(payload: CreateTaskPayload): Promise<TasksResul
 export async function updateTask(payload: UpdateTaskPayload): Promise<TasksResult<Task>> {
   const { id, ...fields } = payload
 
-  const { data, error } = await supabase
-    .from('tasks')
-    .update(fields)
-    .eq('id', id)
-    .select()
-    .single()
+  const { data, error } = await supabase.from('tasks').update(fields).eq('id', id).select().single()
 
   if (error) return { data: null, error: { message: error.message } }
 
@@ -61,17 +64,10 @@ export async function deleteTask(id: string): Promise<TasksResult<null>> {
   return { data: null, error: null }
 }
 
-export async function updateStatus(
-  id: string,
-  status: TaskStatus,
-): Promise<TasksResult<Task>> {
+export async function updateStatus(id: string, status: TaskStatus): Promise<TasksResult<Task>> {
   return updateTask({ id, status })
 }
 
-export async function updatePosition(
-  id: string,
-  x: number,
-  y: number,
-): Promise<TasksResult<Task>> {
+export async function updatePosition(id: string, x: number, y: number): Promise<TasksResult<Task>> {
   return updateTask({ id, position_x: x, position_y: y })
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -18,6 +18,13 @@ const routes: RouteRecordRaw[] = [
     meta: { public: true },
   },
 
+  // Focus mode (full-screen, no nav)
+  {
+    path: '/focus/:taskId',
+    name: 'focus',
+    component: () => import('@/modules/focus/views/FocusView.vue'),
+  },
+
   // Protected routes (with nav layout)
   {
     path: '/',


### PR DESCRIPTION
# feat: Focus mode - single-task distraction-free view

## Description

Implemented focus mode that isolates a single active task in a distraction-free full-screen layout.

## Why?

The POC requires a focus mode that removes all distractions and allows the user to concentrate on a single task.

<img width="1968" height="1007" alt="image" src="https://github.com/user-attachments/assets/1faebcc4-b970-4e64-b581-5910b078e81b" />


## Changes

- **FocusView.vue**: Full-screen view with no navigation, displays task title/description, has "Mark as Completed" and "Exit" buttons
- **Route**: Added `/focus/:taskId` route (outside AppLayout for full-screen)
- **KanbanCard**: Added focus button on featured (first doing) task
- **KanbanColumn**: Added focus event emission
- **KanbanView**: Handles focus navigation
- **tasks.service**: Added `fetchTask` function

## How to test

1. Go to a project's Kanban board
2. Click the focus button (center_focus_strong) on the first task in "Doing" column
3. Should navigate to `/focus/:taskId` with full-screen view
4. Click "Mark as Completed" to mark done and return
5. Or press ESC / click Exit to return without changes

## Branch Information

- **Source Branch:** `feat/8-focus-mode`
- **Target Branch:** `main`